### PR TITLE
Add a README.rst, for DFHack docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,29 @@
+===================
+dscorbett's scripts
+===================
+
+.. todo
+    
+    Someone familiar with the script to fill out and check this readme!
+
+babel
+=====
+An incredibly detailed simulator and random generator for natural languages.
+
+.. warning::
+
+    This script is unfinished.  Make backups before changing your raws!
+
+While incomplete, it already supports a range of features such as composition
+of words from phonemes, loanwords, mispronunciation if a unit is not fluent
+in the language, the effects of historical events on language, and much more.
+
+Usage:
+
+:start:     Start the script
+:stop:      Stop the script
+:test:      Runs some (verbose) tests
+
+Undocumented features include saving translation tables, testing the script,
+overwriting the language raws with generated languages, and so on.
+


### PR DESCRIPTION
The new build process with Sphinx can pull in other .rst format documentation, and we've got it set up to do this as of DFHack pull 697.

Adding a README means these scripts will be documented with DFHack, as well as distributed with DFHack.
